### PR TITLE
add reset method to data collector for symfony 3.4+ compatibility

### DIFF
--- a/src/DataCollector/HandlebarsDataCollector.php
+++ b/src/DataCollector/HandlebarsDataCollector.php
@@ -29,6 +29,11 @@ class HandlebarsDataCollector extends DataCollector implements LateDataCollector
     {
     }
 
+    public function reset()
+    {
+        $this->data = [];
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Having no `reset()` method in a data collector is deprecated in Symfony 3.4, and is not allowed in Symfony 4. This just adds compatibility.